### PR TITLE
fix `Slice#[]=` with negative index

### DIFF
--- a/src/slice.cr
+++ b/src/slice.cr
@@ -49,7 +49,7 @@ struct Slice(T)
 
   def []=(index : Int32, value : T)
     check_read_only!
-    size = check_in_bounds!(index)
+    index = check_in_bounds!(index)
     @pointer[index] = value
   end
 

--- a/test/slice_test.cr
+++ b/test/slice_test.cr
@@ -86,6 +86,8 @@ struct SliceTest < Nano::Test
     slice[1] = 2
     assert slice[0] == 1
     assert slice[1] == 2
+    slice[-1] = 3
+    assert slice[1] == 3
 
     assert_panic do
       other = Slice(Int32).new(2, read_only: true)


### PR DESCRIPTION
There is a similar problem with `Slice#+`, but it is solved not so cleanly.